### PR TITLE
fixed a regression and narrowed number of types

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function admonitionPlugin(md, options) {
       render      = renderDefault,
       type        = "",
       title       = null,
-      types       = ["note", "abstract", "info", "tip", "success", "question", "warning", "failure", "danger", "bug", "example", "quote"];
+      types       = ["note", "hint", "attention", "caution", "danger", "error"];
 
   function renderDefault(tokens, idx, _options, env, self) {
 
@@ -36,7 +36,7 @@ module.exports = function admonitionPlugin(md, options) {
       title = "";
       type = array[0];
       if ( (array.length > 1) ) {
-          title = array[1]
+          title = params.substring(title.length + 2)
       }
 
       if ( title === "" || !title ) {


### PR DESCRIPTION
reinstated an expression allowing for multi-worded title; reduced number of types of boxes to "note", "hint", "attention", "caution", "danger", "error"

I removed a line that was correct in the first place, but the original fix is still in place. 

So, this is my first foray in open source contribution and I don't what the etiquette is. I would like to adapt your plugin to be used in Boostnote (boostnote.io), but in doing so, I have reduced the number of types available to the user (because I can't find appropriate unicode characters to cover your original list.) Would it be alright for me to make a PR with them using a variation of your plugin?